### PR TITLE
Support email notification without SMTP auth.

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -103,12 +103,21 @@ func send(subject, plainBody, htmlBody string, c *Context) error {
 		htmlBody,
 	)
 
-	d := gomail.NewPlainDialer(
-		c.Vargs.Host,
-		c.Vargs.Port,
-		c.Vargs.Username,
-		c.Vargs.Password,
-	)
+	var d *gomail.Dialer
+	if c.Vargs.Username == "" {
+		d = &gomail.Dialer{
+			Host: c.Vargs.Host,
+			Port: c.Vargs.Port,
+			SSL:  c.Vargs.Port == 465,
+		}
+	} else {
+		d = gomail.NewDialer(
+			c.Vargs.Host,
+			c.Vargs.Port,
+			c.Vargs.Username,
+			c.Vargs.Password,
+		)
+	}
 
 	if c.Vargs.SkipVerify {
 		d.TLSConfig = &tls.Config{


### PR DESCRIPTION
Even if `.drone.yml` does not specify `username` and `password`,
`gomail.NewPlainDialer` is still populated with them - albeit empty -
which means they are still being sent to SMTP server. In case of
Google's smtp-relay.gmail.com this will result in an error, even
if CI's server IP address is added to exclusion list allowing it to
skip auth entirely.

This commit constructs `gomail.Dialer` without `username` and `password`
if there was no `username` found in `.drone.yml`.